### PR TITLE
Added status constants

### DIFF
--- a/gocdapi/utils/state.py
+++ b/gocdapi/utils/state.py
@@ -1,0 +1,54 @@
+""" Enumerates results and states used by Go CD. """
+ASSIGNED = 'Assigned'
+BUILDING = 'Building'
+CANCELLED = 'Cancelled'
+COMPLETED = 'Completed'
+COMPLETING = 'Completing'
+DISCONTINUED = 'Discontinued'
+FAILED = 'Failed'
+FAILING = 'Failing'
+PASSED = 'Passed'
+PAUSED = 'Paused'
+PREPARING = 'Preparing'
+RESCHEDULED = 'Rescheduled'
+SCHEDULED = 'Scheduled'
+UNKNOWN = 'Unknown'
+WAITING = 'Waiting'
+
+
+JOB_RESULTS = [
+    CANCELLED,
+    FAILED,
+    PASSED,
+    UNKNOWN,
+]
+
+JOB_STATES = [
+    ASSIGNED,
+    BUILDING,
+    COMPLETED,
+    COMPLETING,
+    DISCONTINUED,
+    PAUSED,
+    PREPARING,
+    RESCHEDULED,
+    SCHEDULED,
+    UNKNOWN,
+    WAITING,
+]
+
+STAGE_RESULTS = [
+    CANCELLED,
+    FAILED,
+    PASSED,
+    UNKNOWN,
+]
+
+STAGE_STATES = [
+    BUILDING,
+    CANCELLED,
+    FAILED,
+    FAILING,
+    PASSED,
+    UNKNOWN,
+]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 import os
 
 PROJECT_ROOT, _ = os.path.split(__file__)
-REVISION = '1.0.3'
+REVISION = '1.0.4'
 PROJECT_NAME = 'gocdapi'
 PROJECT_AUTHORS = "Joao Cravo"
 # Please see readme.rst for a complete list of contributors


### PR DESCRIPTION
Trivial addition to help eliminate magic strings in code that interacts with the Go CD API. This should help reduce keyboarding errors in people's code when matching status constants.

Sourced from: https://www.go.cd/documentation/developer/writing_go_plugins/notification/version_1_0/stage_status_notification.html#request-from-the-server

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/joaogbcravo/gocdapi/11)

<!-- Reviewable:end -->
